### PR TITLE
Make the default format configurable

### DIFF
--- a/config/install/ww_enterprise.settings.yml
+++ b/config/install/ww_enterprise.settings.yml
@@ -1,0 +1,1 @@
+default_filter_format: full_html

--- a/config/schema/ww_enterprise.schema.yml
+++ b/config/schema/ww_enterprise.schema.yml
@@ -1,0 +1,6 @@
+ww_enterprise.settings:
+  type: mapping
+  mapping:
+    default_filter_format:
+      type: string
+      label: Default filter format

--- a/ww_enterprise_field.inc
+++ b/ww_enterprise_field.inc
@@ -1,4 +1,5 @@
 <?php
+use Drupal\filter\Entity\FilterFormat;
 
 /**
  * Validates a request using the Drupal authentication manager.
@@ -1011,12 +1012,12 @@ function deleteExpiredPreviews()
  */
 function checkFilters()
 {
-	// Determine if there is a filter for 'full_html', that it is enabled, and that it is for HTML.
-	/** @var \Drupal\filter\FilterFormatInterface $filter */
-	$filter = entity_load( 'filter_format', 'full_html' );
+	// Determine if there is a default filter, that it is enabled, and that it is for HTML.
+	$default_filter_format = \Drupal::config('ww_enterprise.settings')->get('default_filter_format');
+	$filter = FilterFormat::load( $default_filter_format );
 
 	if ( !$filter || !$filter->status() ){
-		throw new \Exception( 'The mandatory Drupal text format "full_html" is either missing or disabled. Please ' .
+		throw new \Exception( 'The mandatory Drupal text format "' . $default_filter_format . '" (set by ww_enterprise.settings:default_filter_format) is either missing or disabled. Please ' .
 			'ensure that the format exists and is not disabled.' );
 	}
 }
@@ -1144,7 +1145,7 @@ function mapNodeValues( $node, $formValues, $previewMode )
 						$attachments = ( isset( $values[0]['attachments'] ) ) ? $values[0]['attachments'] : null;
 						$val = resolveInlineImages( $content, $attachments );
 						$node->$field_machine_name->value = $val;
-						$node->$field_machine_name->format = 'full_html';
+						$node->$field_machine_name->format = \Drupal::config('ww_enterprise.settings')->get('default_filter_format');
 						break;
 					case 'text_with_summary': // text (formatted, long, summary)
 						$content = null;
@@ -1170,7 +1171,7 @@ function mapNodeValues( $node, $formValues, $previewMode )
 						$summaryContent = resolveInlineImages( $content, $attachments );
 						$node->$field_machine_name->summary = $summaryContent;
 
-						$node->$field_machine_name->format = 'full_html';
+						$node->$field_machine_name->format = \Drupal::config('ww_enterprise.settings')->get('default_filter_format');
 						break;
 					case 'taxonomy_term_reference': //
 						$termIds = array();

--- a/ww_enterprise_xmlrpc.inc
+++ b/ww_enterprise_xmlrpc.inc
@@ -116,7 +116,7 @@ function ww_enterprise_xmlrpc_getContentTypes( $enableTestMode=false )
 			throw new \Exception( 'Could not authenticate the user.' );
 		}
 
-		checkFilters(); // Check the full_html filter.
+		checkFilters(); // Check the default filter format.
 
 		// Load all node types.
 		$types = \Drupal\node\Entity\NodeType::loadMultiple();


### PR DESCRIPTION
The module should not hardcode the full_html filter format. Converted it to a configuration that I can override from our install profile.

Still not an optimal solution, The format to use should be configurable somehow per field, there are contrib modules that allow to control which formats are available per field, the default might always be the correct one.

Also, users might not have access to this format, which makes it impossible for them to change anything in Drupal.