### PR TITLE
Remove user.flood hack, avoid custom re-authentication instead

### DIFF
--- a/src/Controller/UploadController.php
+++ b/src/Controller/UploadController.php
@@ -88,7 +88,7 @@ class UploadController extends ControllerBase
 			/** @var \Drupal\node\Entity\NodeType $type */
 			if ( $types ) foreach ( $types as $type ) {
 				if ( $type->uuid() == $originalUuid ) {
-					$originalType = $type->type;
+					$originalType = $type->id();
 					$id = $type->id();
 					break;
 				}

--- a/ww_enterprise_field.inc
+++ b/ww_enterprise_field.inc
@@ -1,5 +1,8 @@
 <?php
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\filter\Entity\FilterFormat;
+use Drupal\user\UserInterface;
 
 /**
  * Validates a request using the Drupal authentication manager.
@@ -12,16 +15,21 @@ use Drupal\filter\Entity\FilterFormat;
  */
 function validateRequest( \Symfony\Component\HttpFoundation\Request $request )
 {
-	// For some odd reason, the Drupal flood control already logs 5 failed attempts when we attempt to authenticate a
-	// single user. Five is also the default amount for the flood control setting to block further attempts. It can be
-	// that the Drupal core attempts multiple authentication providers and thus generates these logged attempts in the
-	// flood table. As a work around for now we set the maximum user attempts to 50 in the configuration.
-	$limit = \Drupal::config( 'user.flood' )->get( 'user_limit' );
-	if ($limit < 50 ) {
-		\Drupal::configFactory()->getEditable('user.flood')->set('user_limit', 50 )->save();
+
+	// Check if the current user is already authenticated, in that case, return
+	// that. This relies on a patched xmlrpc.routing.yml that enables basic_auth
+	// for the xmlrpc.php route.
+	$user = \Drupal::currentUser();
+	if ($user instanceof AccountProxyInterface) {
+		$user = $user->getAccount();
+	}
+	if ( $user->isAuthenticated() && $user instanceof UserInterface ) {
+		return $user;
 	}
 
 	// Authenticate anonymous users and those that have not yet been authenticated.
+	// @todo This module should not have to do this. It is not even clear how it
+	//   can work, without patching rest.module.
 	/** @var \Drupal\user\Entity\User $user */
 	$user = \Drupal::service( 'authentication' )->authenticate( $request );
 	$authenticated = ( $user instanceof \Drupal\user\Entity\User && $user->isAuthenticated() && !$user->isAnonymous() );

--- a/ww_enterprise_xmlrpc.inc
+++ b/ww_enterprise_xmlrpc.inc
@@ -128,7 +128,7 @@ function ww_enterprise_xmlrpc_getContentTypes( $enableTestMode=false )
 				// Transform the content type into something enterprise can use:
 				$contentTypeInformation[$type->getOriginalId()] = array(
 					'type' => $type->id(),
-					'name' => $type->get('name'),
+					'name' => $type->label(),
 					'description' => strip_tags( $type->getDescription()), // Strip out h tags.
 					'original' => $type->uuid()
 				);


### PR DESCRIPTION
The flood configuration change is a hack that is broken with beta6, it would have to be changed.

But doing it is wrong anyway, code like this should never just change configuration at runtime.

This should not be a problem as long as you provide correct credentials, flood is only increased on unsuccessful authentications.

As I mentioned before, I do not understand how this code can even work right now. Instead, I am now just getting the current user, that was already authenticated by changing xmlrpc.routing.yml. This should not cause an excessive flood growth.

Also, updating access to protected node type properties.