### PR TITLE
Remove reinstall in testConfig, this re-installs tables and configuration

### DIFF
--- a/ww_enterprise_xmlrpc.inc
+++ b/ww_enterprise_xmlrpc.inc
@@ -497,11 +497,6 @@ function ww_enterprise_xmlrpc_testConfig( $enableTestMode=false )
 {
 	$result = null;
 
-	// Automatically reload the ww_enterprise module for Drupal to ensure we always have the most recent
-	// information cached in case the module changed.
-	\Drupal::service('module_installer')->uninstall( array( 'ww_enterprise' ), FALSE);
-	\Drupal::service('module_installer')->install( array( 'ww_enterprise' ), FALSE);
-
 	try {
 		checkFilters();
 


### PR DESCRIPTION
If there is information cached by the module, then it would be enough  to just clear those caches, but I don't see what that would be.

This repeatedly broke our site, because it was reinstalling with the original configuration that we changed.