### PR TITLE
Convert taxonomy_term_reference integration to entity_reference

### DIFF
--- a/ww_enterprise.module
+++ b/ww_enterprise.module
@@ -21,7 +21,7 @@ include_once(drupal_get_path('module', 'ww_enterprise').'/ww_enterprise_xmlrpc.i
  *
  * @return \Drupal\Core\Access\AccessResult The access result, to be handled by the Drupal core.
  */
-function ww_enterprise_node_access( \Drupal\node\NodeInterface $node, $op, \Drupal\Core\Session\AccountInterface $account, $langcode )
+function ww_enterprise_node_access( \Drupal\node\NodeInterface $node, $op, \Drupal\Core\Session\AccountInterface $account )
 {
 	// We are only interested in view actions.
 	if ( $op != 'view' || !\Drupal::hasRequest() ) {

--- a/ww_enterprise.module
+++ b/ww_enterprise.module
@@ -17,7 +17,6 @@ include_once(drupal_get_path('module', 'ww_enterprise').'/ww_enterprise_xmlrpc.i
  * @param \Drupal\node\NodeInterface $node The node being accessed.
  * @param string $op The action 'view', 'create', 'update', 'delete'.
  * @param \Drupal\Core\Session\AccountInterface $account The account data. (required by interface).
- * @param string $langcode The language code. The language code (required by interface).
  *
  * @return \Drupal\Core\Access\AccessResult The access result, to be handled by the Drupal core.
  */

--- a/ww_enterprise_field.inc
+++ b/ww_enterprise_field.inc
@@ -1,4 +1,5 @@
 <?php
+use Drupal\Core\Form\OptGroup;
 use Drupal\Core\Session\AccountInterface;
 use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\filter\Entity\FilterFormat;
@@ -515,90 +516,60 @@ function getEnterpriseNodeFields( $contentType )
 				$nodeProperties['default_value'] = $nodeProperties['list_options'][$defaultId];
 			}
 
-			if ( $nodeProperties['type'] == 'taxonomy_term_reference' && ( $nodeProperties['widget_type'] == 'taxonomy_autocomplete' || $nodeProperties['widget_type'] == 'options_select' || $nodeProperties['widget_type'] == 'options_buttons') ) {
-				$defaultValue = '';
-				$allowedValues = options_allowed_values( $field->getFieldStorageDefinition(), null);
-				$vid = $allowedValues[0]['vocabulary'];
-				$voc = \Drupal\taxonomy\Entity\Vocabulary::load( $vid );
-				$vocabulary = $voc->label();
+			// @todo Temporary limit support for entity references to term references.
+			if ($nodeProperties['type'] == 'entity_reference' && $field->getFieldStorageDefinition()->getSetting('target_type') == 'taxonomy_term') {
 
-				/** @var \Drupal\taxonomy\Entity\Vocabulary $voc */
-				$storedTermEntity = getWoodWingSuggestionEntity( $voc->uuid() );
-				$ww_term_entity = (!empty($storedTermEntity)) ? $storedTermEntity : null;
-
-				if ( $nodeProperties['widget_type'] == 'taxonomy_autocomplete' ) {
-					if ( $nodeProperties['cardinality'] == 1 ) {
-						$tid = $nodeProperties['default_value'][0]['target_id'];
-						if ( !is_null( $tid ) ) { // option -none-
-							$terms = \Drupal\taxonomy\Entity\Term::loadMultiple( array ( $tid ) );
-							/** @var \Drupal\taxonomy\Entity\Term $term */
-							$term = $terms[$tid];
-							$defaultValue = $term->getName();
-						}
-					} else {
-						$totalDefaultValues = count( $nodeProperties['default_value'] );
-						$defaultValues = array();
-						for( $ctr=0; $ctr < $totalDefaultValues; $ctr++ ) {
-							$tid = $nodeProperties['default_value'][$ctr]['target_id'];
-							if( is_null( $tid ) ) {
-								continue; // Don't add the option '- None -' as default when there is more than one default.
-							}
-							$terms = \Drupal\taxonomy\Entity\Term::loadMultiple( array ( $tid ));
-							$term = $terms[$tid];
-							$defaultValues[] = $term->getName();
-						}
-						if( $defaultValues ) {
-							$defaultValue = implode( ',', $defaultValues );
-						}
-					}
-				} elseif ( $nodeProperties['widget_type'] == 'options_select' || $nodeProperties['widget_type'] == 'options_buttons' ) {
-					$tree = \Drupal::entityManager()->getStorage( 'taxonomy_term' )->loadTree( $vid, 0, NULL, TRUE );
-					$listOptionsValues = array();
-					if ( $tree ) foreach ( $tree as $term ) {
-						/** @var Drupal\taxonomy\Entity\Term $term */
-						/** @var \Drupal\Core\Field\Plugin\Field\FieldType\StringItem $name */
-						$name = $term->name[0];
-						$name = $name->getValue();
-						$listOptionsValues[]  = $name['value'];
-					}
-
-					if( !$nodeProperties['required'] ) {
-						// None is only allowed when the field is not a mandatory field.
-						array_unshift( $listOptionsValues, '- None -' ); // In D8, 'none' option is always set at the top of the list.
-					} else {
-						array_unshift( $listOptionsValues, '' );
-					}
-					$nodeProperties['list_options'] = $listOptionsValues; // Only store the options values(labels).
-
-					$defaultValue = null;
-					if( $nodeProperties['cardinality'] == 1 ) {
-						$tid = $nodeProperties['default_value'][0]['target_id'];
-						if ( !is_null( $tid ) ) {
-							$terms = \Drupal\taxonomy\Entity\Term::loadMultiple( array ( $tid ) );
-							$term = $terms[$tid];
-							$defaultValue = $term->getName();
-						}
-					} else { // When the cardinality is greater than one, there can be more than one default value.
-						$totalDefaultValues = count( $nodeProperties['default_value'] );
-						$defaultValues = array();
-						for( $ctr=0; $ctr < $totalDefaultValues; $ctr++ ) {
-							$tid = $nodeProperties['default_value'][$ctr]['target_id'];
-							if( is_null( $tid ) ) {
-								continue; // Don't add the option '- None -' as default when there is more than one default.
-							}
-							$terms = \Drupal\taxonomy\Entity\Term::loadMultiple( array ( $tid ));
-							$term = $terms[$tid];
-							$defaultValues[] = $term->getName();
-						}
-						if( $defaultValues ) {
-							$defaultValue = implode( ',', $defaultValues );
-						}
-					}
+				$handlerSettings = $field->getSetting('handler_settings');
+				$vid = NULL;
+				if (!empty($handlerSettings['target_bundles'])) {
+					$vid = reset($handlerSettings['target_bundles']);
 				}
 
-				$nodeProperties['vocabulary_name'] = $vocabulary;
-				$nodeProperties['ww_term_entity'] = $ww_term_entity;
-				$nodeProperties['default_value'] = $defaultValue;
+				if ($vid) {
+					$vocabulary = \Drupal\taxonomy\Entity\Vocabulary::load($vid);
+					$nodeProperties['vocabulary_name'] = $vocabulary->label();
+					$nodeProperties['type'] = 'taxonomy_term_reference';
+
+					/** @var \Drupal\taxonomy\Entity\Vocabulary $vocabulary */
+					$storedTermEntity = getWoodWingSuggestionEntity( $vocabulary->uuid() );
+					$nodeProperties['ww_term_entity'] = (!empty($storedTermEntity)) ? $storedTermEntity : null;
+				}
+			}
+
+			// This is only executed if we were able to detect the referenced
+			// vocabulary above.
+			if ( $nodeProperties['type'] == 'taxonomy_term_reference') {
+
+				$defaultValues = [];
+				foreach ($initializedNode->$key as $item) {
+					if ($item->entity) {
+						$defaultValues[] = $item->entity->label();
+					}
+				}
+				$nodeProperties['default_value'] = implode(',', $defaultValues);
+
+				if ( $nodeProperties['widget_type'] == 'options_select' || $nodeProperties['widget_type'] == 'options_buttons' ) {
+					// Limit the settable options for the current user account.
+					$listOptionsValues = $field
+						->getFieldStorageDefinition()
+						->getOptionsProvider('target_id', $initializedNode)
+						->getSettableOptions(\Drupal::currentUser());
+					$context = array(
+						'fieldDefinition' => $field,
+						'entity' => $initializedNode,
+					);
+					\Drupal::moduleHandler()->alter('options_list', $options, $context);
+
+					// Remove leading -, assume those are depth marker.
+					// @todo Find a way to improve this.
+					$listOptionsValues = array_map(function ($value) {
+						return ltrim($value, '-');
+					}, $listOptionsValues);
+
+					// Flatten and ensure a numeric list.
+					$nodeProperties['list_options'] = array_values(OptGroup::flattenOptions($listOptionsValues));
+				}
+
 			}
 
 			$nodeProperties['display_name'] = $field->getLabel(); // Field display name;
@@ -1158,7 +1129,7 @@ function mapNodeValues( $node, $formValues, $previewMode )
 
 			if ( !is_null( $field_machine_name ) ) {
 				$val = null;
-				$fieldType = $node->$field_machine_name->getFieldDefinition()->field_type;
+				$fieldType = $node->$field_machine_name->getFieldDefinition()->getType();
 				switch ( $fieldType ) {
 					case 'boolean' :
 						$val = intval( $values[0] );
@@ -1239,7 +1210,8 @@ function mapNodeValues( $node, $formValues, $previewMode )
 
 						$node->$field_machine_name->format = \Drupal::config('ww_enterprise.settings')->get('default_filter_format');
 						break;
-					case 'taxonomy_term_reference': //
+					case 'entity_reference': //
+						// @todo Expand to support all kinds of references.
 						$termIds = array();
 						foreach ( $values as $value ) {
 							if ($value != '') {

--- a/ww_enterprise_field.inc
+++ b/ww_enterprise_field.inc
@@ -498,7 +498,8 @@ function getEnterpriseNodeFields( $contentType )
 			$dateTimeType = null;
 			if ( $nodeProperties['widget_type'] == 'datetime_default' ){
 				$dateTimeType = $field->getSetting( 'datetime_type' );
-				$nodeProperties['default_value'] = ( $nodeProperties['default_value'][0]['value'] );
+
+				$nodeProperties['default_value'] = isset($nodeProperties['default_value'][0]['value']) ? ( $nodeProperties['default_value'][0]['value'] ) : NULL;
 			}
 
 			// Handle comment field.
@@ -643,7 +644,7 @@ function getEnterpriseNodeFields( $contentType )
 				// If the max value is not determined, we set the maximum for ContentStation, which is 2147483647.
 				$nodeProperties['max_value'] = ( empty( $max_value ) ) ? '2147483647' : $max_value;
 				$nodeProperties['min_value'] = ( empty( $min_value ) ) ? '-999999999' : $min_value;
-				$nodeProperties['default_value'] = ( $nodeProperties['default_value'][0]['value'] )
+				$nodeProperties['default_value'] = isset( $nodeProperties['default_value'][0]['value'] )
 					? ( $nodeProperties['default_value'][0]['value'] )
 					: null;
 
@@ -651,7 +652,7 @@ function getEnterpriseNodeFields( $contentType )
 				// ContentStation restriction, take the smallest maximum.
 				$nodeProperties['max_value'] = ( empty( $max_value) ) ? '99999999.99' : $max_value;
 				$nodeProperties['min_value'] = ( empty( $min_value) ) ? '-999999.99' : $min_value;
-				$nodeProperties['default_value'] = ( $nodeProperties['default_value'][0]['value'] )
+				$nodeProperties['default_value'] = isset( $nodeProperties['default_value'][0]['value'] )
 					? ( $nodeProperties['default_value'][0]['value'] )
 					: null;
 			}
@@ -684,7 +685,7 @@ function getEnterpriseNodeFields( $contentType )
 
 				$defaultValue = null;
 				if( $nodeProperties['cardinality'] == 1 ) {
-					$defaultKey = $nodeProperties['default_value'][0]['value'];
+					$defaultKey = isset($nodeProperties['default_value'][0]['value']) ? $nodeProperties['default_value'][0]['value'] : NULL;
 					$defaultValue = is_null( $defaultKey ) ? null : $listOptions[$defaultKey];
 				} else { // When the cardinality is greater than one, there can be more than one default value.
 					$totalDefaultValues = count( $nodeProperties['default_value'] );
@@ -950,7 +951,7 @@ function getEnterprisePropertyInfoType( $widgetType, $fieldInfoType, $cardinalit
 		case 'options_buttons' :
 		case 'options_select' :
 			$propertyInfoType = 'list';
-			if ( in_array( $fieldInfoType, array( 'list_float', 'list_integer', 'list_string', 'taxonomy_term_reference' ) )
+			if ( in_array( $fieldInfoType, array( 'list_float', 'list_integer', 'list_string', 'entity_reference' ) )
 				&& $cardinality != 1
 			) {
 				$propertyInfoType = 'multilist';
@@ -982,7 +983,9 @@ function getEnterprisePropertyInfoType( $widgetType, $fieldInfoType, $cardinalit
 		case 'text_textarea_with_summary': // Text (formatted, long, summary)
 			$propertyInfoType = ( $hasTextFilter ) ? 'articlecomponentselector' : 'multiline';
 			break;
-		case 'taxonomy_autocomplete' :
+		case 'entity_reference_autocomplete' :
+		case 'entity_reference_autocomplete_tags' :
+			// @todo Is this the correct behavior for non-tags autocomplete?
 			$propertyInfoType = 'multistring';
 			break;
 		case 'datetime_default' :

--- a/ww_enterprise_field.inc
+++ b/ww_enterprise_field.inc
@@ -521,13 +521,17 @@ function getEnterpriseNodeFields( $contentType )
 			if ($nodeProperties['type'] == 'entity_reference' && $field->getFieldStorageDefinition()->getSetting('target_type') == 'taxonomy_term') {
 
 				$handlerSettings = $field->getSetting('handler_settings');
-				$vid = NULL;
+
 				if (!empty($handlerSettings['target_bundles'])) {
 					$vid = reset($handlerSettings['target_bundles']);
-				}
-
-				if ($vid) {
 					$vocabulary = \Drupal\taxonomy\Entity\Vocabulary::load($vid);
+
+					// Avoid a fatal error if the vocabulary can not be loaded.
+					if ( !$vocabulary ) {
+						\Drupal::logger( 'ww_enterprise' )->error( 'Failed to load vocabulary @vid, used by field @field_name on node type @type.', ['@vid' => $vid, '@field_name' => $key, '@type' => $field->getTargetBundle()] );
+						continue;
+					}
+
 					$nodeProperties['vocabulary_name'] = $vocabulary->label();
 					$nodeProperties['type'] = 'taxonomy_term_reference';
 


### PR DESCRIPTION
Refactoring the taxonomy term reference support to use generic entity reference fields, since term reference field was removed from Drupal Core.

This is still limited to term reference fields, but it is a large step towards supporting all kinds of references. To complete that, there are changes necessary on the content station side, however (No longer expose vocabulary in the definition, go through the field ID for autocomplete/suggestions.

This has not been tested yet, only manual inspection of the exported field definitions. 